### PR TITLE
Don't notify for binding necklaces if disabled in config

### DIFF
--- a/src/main/java/com/gotrleech/GotrLeechPlugin.java
+++ b/src/main/java/com/gotrleech/GotrLeechPlugin.java
@@ -102,16 +102,18 @@ public class GotrLeechPlugin extends Plugin {
 
     private void gameOver() {
         if (!config.notifyOnEndForNextGame()) return;
+        
+        if (config.minBindingNecklaceChargesRequired() > 0) {
+            if (gotrItemManager.getBindingNecklaces().getCount() < 1) {
+                notifier.notify("You are out of binding necklaces!");
+                return;
+            }
 
-        if (gotrItemManager.getBindingNecklaces().getCount() < 1) {
-            notifier.notify("You are out of binding necklaces!");
-            return;
-        }
-
-        int bindingCharges = gotrPlayerState.getBindingNecklaceCharges();
-        if (bindingCharges < config.minBindingNecklaceChargesRequired()) {
-            notifier.notify("You need more binding necklace charges for the next round!");
-            return;
+            int bindingCharges = gotrPlayerState.getBindingNecklaceCharges();
+            if (bindingCharges < config.minBindingNecklaceChargesRequired()) {
+                notifier.notify("You need more binding necklace charges for the next round!");
+                return;
+            }
         }
 
         if (gotrItemManager.getUnchargedCells().getCount() < config.minUnchargedCellsRequired()) {


### PR DESCRIPTION
The config currently states "Set to 0 if not using binding necklaces", but you still get RuneLite notifications that you're out of binding necklaces at the start of every game.