### PR TITLE
V1.1 (Update Config To Allow Switching 150 & 300 Points)

### DIFF
--- a/src/main/java/com/gotrleech/GotrLeechConfig.java
+++ b/src/main/java/com/gotrleech/GotrLeechConfig.java
@@ -73,4 +73,15 @@ public interface GotrLeechConfig extends Config {
     default int minUnchargedCellsRequired() {
         return 1;
     }
+
+    @ConfigItem(
+            keyName = "highPointRequirement",
+            name = "300 point requirement",
+            description = "If enabled, the plugin will require 300 points instead of 150",
+            position = 6
+    )
+    default boolean highPointRequirement() {
+        return false;
+    }
+
 }

--- a/src/main/java/com/gotrleech/GotrLeechPlugin.java
+++ b/src/main/java/com/gotrleech/GotrLeechPlugin.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 )
 public class GotrLeechPlugin extends Plugin {
 
-    public static final int ENERGY_REQUIRED = 150; // 150 energy required to qualify for points/xp
     static final String CONFIG_GROUP = "gotrLeech";
 
     @Inject
@@ -123,7 +122,8 @@ public class GotrLeechPlugin extends Plugin {
     private void sixtyPercent() {
         if (!config.notifyOnSixtyPercentMessage()) return;
 
-        int pointsToQualify = ENERGY_REQUIRED - gotrPlayerState.getTotalEnergy();
+        int requiredEnergy = config.highPointRequirement() ? 300 : 150;
+        int pointsToQualify = requiredEnergy - gotrPlayerState.getTotalEnergy();
         if (pointsToQualify > 0) {
             notifier.notify("You still need " + pointsToQualify + " more points to qualify for GotR rewards!");
             return;

--- a/src/main/java/com/gotrleech/overlay/GotrOverlayPanel.java
+++ b/src/main/java/com/gotrleech/overlay/GotrOverlayPanel.java
@@ -58,7 +58,8 @@ public class GotrOverlayPanel extends OverlayPanel {
 
         renderBool(gotrPlayerState.isMining(), "Is Mining");
 
-        renderInt(gotrPlayerState.getTotalEnergy(), "Total Energy", GotrLeechPlugin.ENERGY_REQUIRED);
+        int requiredEnergy = config.highPointRequirement() ? 300 : 150;
+        renderInt(gotrPlayerState.getTotalEnergy(), "Total Energy", requiredEnergy);
         panelComponent.getChildren().add(LineComponent.builder().build());
 
         if (config.minBindingNecklaceChargesRequired() > 0) {


### PR DESCRIPTION
Option to change the default 150 points to 300 points so users can grind for the 2 rewards at 300 points and then AFK mining

Have only changed it so it changes 150 to 300, It will still send the warning at 60% if enabled for either 150 or 300 points.